### PR TITLE
Add new use_module_phpstan_config option

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -11,6 +11,11 @@ on:
         description: 'LocalGov Drupal module path'
         required: true
         type: string
+      use_module_phpstan_config:
+        description: 'Use phpstan.neon from the module under test, instead of the drupal root.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -137,6 +142,8 @@ jobs:
     name: Static analysis checks
     needs: build
     runs-on: ubuntu-latest
+    env:
+      PHPSTAN_NEON_PATH: "./phpstan.neon"
 
     strategy:
       fail-fast: false
@@ -162,10 +169,14 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
+      - name: Override phpstan.neon path if requested
+        if: ${{inputs.use_module_phpstan_config}}
+        run: echo "PHPSTAN_NEON_PATH=\"${{inputs.project_path}}/phpstan.neon\"" >> $GITHUB_ENV
+
       - name: Run static analysis checks
         run: |
           cd html
-          ./bin/phpstan analyse -c ./phpstan.neon ${{inputs.project_path}}
+          ./bin/phpstan analyse -c ${{ env.PHPSTAN_NEON_PATH }} ${{inputs.project_path}}
   
   phpunit:
     name: PHPUnit tests


### PR DESCRIPTION
This change adds a new optional boolean input called use_module_phpstan_config. It's defaulted to false, which will use the phpstan.neon from the project.

If it's set to true it'll use phpstan.neon from the module under test. This lets module authors set the level to a higher one if they wish, etc.