### PR TITLE
Fix latest release lookup when target branch contains minor release

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Get the latest tagged release for branch version
         run: |
-          LATEST_RELEASE=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${GIT_BASE%'.x'} | grep -Po '(?<=refs/tags/)[^"]+' | tail -1)
+          LATEST_RELEASE=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${GIT_BASE%%.*} | grep -Po '(?<=refs/tags/)[^"]+' | tail -1)
           if [ -z $LATEST_RELEASE ]; then LATEST_RELEASE=1; fi
           echo "LATEST_RELEASE=${LATEST_RELEASE}" >> $GITHUB_ENV
 


### PR DESCRIPTION
## What does this change?

When there's a minor release value in the target branch (ie 1.8.x) determining the latest release fails unless there's already been a release for this value. We only need to get the latest release for the latest major version, which this now does.

## How to test

Check PRs in Alert Banner.

With minor version in target: https://github.com/localgovdrupal/localgov_alert_banner/pull/357
With only major version in target: https://github.com/localgovdrupal/localgov_alert_banner/pull/358
