### PR TITLE
fix: docker-compose error

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -200,7 +200,7 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Start Docker environment
-        run: docker-compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose.yml up -d
 
       - name: Run PHPUnit tests
         run: |


### PR DESCRIPTION
## What does this change?

Fixes docker-compose not found error on workflows due to docker-compose v1 being deprecated and removed from GitHub Action runners/images

See https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/
