### PR TITLE
ci: add ESLint and Stylelint checks to workflows

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           cd html/web/core
           npm i
-          node ./node_modules/eslint/bin/eslint.js ./html/${{inputs.project_path}}
+          node ./node_modules/eslint/bin/eslint.js ../../${{inputs.project_path}}
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -124,13 +124,20 @@ jobs:
           - '8.3'
 
     steps:
+      - name: Cached workspace
+        uses: actions/cache@v4
+        with:
+          path: ./html
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
+          restore-keys: |
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
+
       - name: Run coding standards checks
-        #if: hashFiles(format('{0}/**/*.js', inputs.project_path)) != '' }}
+        #if: hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
-          ls
           cd html/web/core
           npm i
-          node ./node_modules/eslint/bin/eslint.js ${{inputs.project_path}}
+          node ./node_modules/eslint/bin/eslint.js ./html/${{inputs.project_path}}
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -133,7 +133,7 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Run coding standards checks
-        continue-on-error: true
+        #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
@@ -165,15 +165,47 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Run coding standards checks
-        continue-on-error: true
+        #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
           node ./node_modules/eslint/bin/eslint.js --ext .yml --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 
+  stylelint:
+    name: Stylelint checks
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.3'
+
+    steps:
+      - name: Cached workspace
+        uses: actions/cache@v4
+        with:
+          path: ./html
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
+          restore-keys: |
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
+
+      - name: Run coding standards checks
+        #continue-on-error: true
+        if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
+        run: |
+          cd html/web/core
+          npm i
+          node ./node_modules/.bin/stylelint --ignore-path .stylelintignore --config .stylelintrc.json ../../${{inputs.project_path}}/**/*.css
+
   phpcs:
-    name: Coding standards checks
+    name: PHP coding standards checks
     needs: build
     runs-on: ubuntu-latest
 
@@ -207,7 +239,7 @@ jobs:
           ./bin/phpcs -p ${{inputs.project_path}}
   
   phpstan:
-    name: Static analysis checks
+    name: PHP static analysis checks
     needs: build
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -138,7 +138,6 @@ jobs:
           npm i
 
       - name: Run coding standards checks
-        #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
@@ -174,7 +173,6 @@ jobs:
           npm i
 
       - name: Run coding standards checks
-        #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
@@ -210,7 +208,6 @@ jobs:
           npm i
 
       - name: Run coding standards checks
-        #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
@@ -293,7 +290,7 @@ jobs:
   
   phpunit:
     name: PHPUnit tests
-    needs: [build,eslint_js,eslint_yaml,stylelint,phpcs,phpstan]
+    needs: [build,phpcs,phpstan]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -133,7 +133,8 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Run coding standards checks
-        if: hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
+        continue-on-error: true
+        if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
@@ -164,7 +165,8 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Run coding standards checks
-        if: hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
+        continue-on-error: true
+        if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -286,6 +286,7 @@ jobs:
         run: echo "PHPSTAN_NEON_PATH=\"${{inputs.project_path}}/phpstan.neon\"" >> $GITHUB_ENV
 
       - name: Run static analysis checks
+        if: ${{ hashFiles(format('./html/{0}/**/*.inc', inputs.project_path), format('./html/{0}/**/*.install', inputs.project_path), format('./html/{0}/**/*.info', inputs.project_path), format('./html/{0}/**/*.test', inputs.project_path), format('./html/{0}/**/*.module', inputs.project_path), format('./html/{0}/**/*.php', inputs.project_path), format('./html/{0}/**/*.profile', inputs.project_path), format('./html/{0}/**/*.test', inputs.project_path), format('./html/{0}/**/*.theme', inputs.project_path)) != '' }}
         run: |
           cd html
           ./bin/phpstan analyse -c ${{ env.PHPSTAN_NEON_PATH }} ${{inputs.project_path}}

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -214,7 +214,7 @@ jobs:
         if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
-          node ./node_modules/.bin/stylelint --ignore-path .stylelintignore --config .stylelintrc.json ../../${{inputs.project_path}}/**/*.css
+          node ./node_modules/.bin/stylelint --ignore-path .stylelintignore --config .stylelintrc.json "../../${{inputs.project_path}}/**/*.css"
 
   phpcs:
     name: PHP coding standards checks

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -177,8 +177,6 @@ jobs:
         #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
-          echo ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) }}
-          echo ${{ format('./html/{0}/**/*.yml', inputs.project_path) }}
           cd html/web/core
           node ./node_modules/eslint/bin/eslint.js --ext .yml --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -125,7 +125,9 @@ jobs:
 
     steps:
       - name: Run coding standards checks
+        #if: hashFiles(format('{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
+          ls
           cd html/web/core
           npm i
           node ./node_modules/eslint/bin/eslint.js ${{inputs.project_path}}

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -108,7 +108,7 @@ jobs:
         if: hashFiles('./html/${{inputs.project_path}}/composer.json') != ''
         run: jq --raw-output '.["require-dev"] | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/${{inputs.project_path}}/composer.json | xargs composer --working-dir=./html require
 
-  eslint:
+  eslint_js:
     name: ESLint javascript checks
     needs: build
     runs-on: ubuntu-latest
@@ -133,11 +133,42 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Run coding standards checks
-        #if: hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
+        if: hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
-          node ./node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
+          node ./node_modules/eslint/bin/eslint.js --ext .js --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
+
+  eslint_yaml:
+    name: ESLint yaml checks
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.3'
+
+    steps:
+      - name: Cached workspace
+        uses: actions/cache@v4
+        with:
+          path: ./html
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
+          restore-keys: |
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
+
+      - name: Run coding standards checks
+        if: hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
+        run: |
+          cd html/web/core
+          npm i
+          node ./node_modules/eslint/bin/eslint.js --ext .yml --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -132,12 +132,16 @@ jobs:
           restore-keys: |
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
+      - name: Install packages
+        run: |
+          cd html/web/core
+          npm i
+
       - name: Run coding standards checks
         #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
-          npm i
           node ./node_modules/eslint/bin/eslint.js --ext .js --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 
   eslint_yaml:
@@ -164,12 +168,16 @@ jobs:
           restore-keys: |
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
+      - name: Install packages
+        run: |
+          cd html/web/core
+          npm i
+
       - name: Run coding standards checks
         #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
-          npm i
           node ./node_modules/eslint/bin/eslint.js --ext .yml --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 
   stylelint:
@@ -196,12 +204,16 @@ jobs:
           restore-keys: |
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
+      - name: Install packages
+        run: |
+          cd html/web/core
+          npm i
+
       - name: Run coding standards checks
         #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
-          npm i
           node ./node_modules/.bin/stylelint --ignore-path .stylelintignore --config .stylelintrc.json ../../${{inputs.project_path}}/**/*.css
 
   phpcs:

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -133,6 +133,7 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
+        if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
@@ -168,6 +169,7 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
+        if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
@@ -203,6 +205,7 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
+        if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -109,7 +109,7 @@ jobs:
         run: jq --raw-output '.["require-dev"] | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/${{inputs.project_path}}/composer.json | xargs composer --working-dir=./html require
 
   eslint:
-    name: ESLint JS checks
+    name: ESLint javascript checks
     needs: build
     runs-on: ubuntu-latest
 
@@ -137,7 +137,7 @@ jobs:
         run: |
           cd html/web/core
           npm i
-          node ./node_modules/eslint/bin/eslint.js ../../${{inputs.project_path}}
+          node ./node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -177,6 +177,8 @@ jobs:
         #continue-on-error: true
         if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
+          echo ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) }}
+          echo ${{ format('./html/{0}/**/*.yml', inputs.project_path) }}
           cd html/web/core
           node ./node_modules/eslint/bin/eslint.js --ext .yml --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -280,7 +280,7 @@ jobs:
   
   phpunit:
     name: PHPUnit tests
-    needs: build
+    needs: [build,eslint_js,eslint_yaml,stylelint,phpcs,phpstan]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -108,6 +108,28 @@ jobs:
         if: hashFiles('./html/${{inputs.project_path}}/composer.json') != ''
         run: jq --raw-output '.["require-dev"] | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/${{inputs.project_path}}/composer.json | xargs composer --working-dir=./html require
 
+  eslint:
+    name: ESLint JS checks
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.3'
+
+    steps:
+      - name: Run coding standards checks
+        run: |
+          cd html/web/core
+          npm i
+          node ./node_modules/eslint/bin/eslint.js ${{inputs.project_path}}
+
   phpcs:
     name: Coding standards checks
     needs: build


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds #10 and #12 in this PR which adds the following checks to the workflows, using Drupal Core's recommended coding standards

- ESLint for js files if they exist
- ESLint for yml files if they exist
- Stylelint for css files if they exist

This will be useful to have in place as these checks are also part of the drupal.org contrib pipelines which use GitLab should modules move to there in future.

The ESLint and Stylelint checks are on by default, but do not prevent phpunit from running.

~Currently to show it working `continue-on-error` is commented out, we will need to discuss whether to use `continue-on-error: true`. The downside to this is that GitHub UI will show a green tick and it's down to the user to check if it has succeeded manually. There is a long discussion at https://github.com/orgs/community/discussions/15452 asking GitHub to introduce a warning/skipped/orange colour similar to GitLab.~

## How to test

Example on alert banner: https://github.com/localgovdrupal/localgov_alert_banner/actions/runs/12215511355

Example on base theme: https://github.com/localgovdrupal/localgov_base/actions/runs/12215438152

Example job vacancies (no php files): https://github.com/localgovdrupal/localgov_job_vacancies/actions/runs/12215522991