### PR TITLE
ci: use phpunit for modules

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -222,4 +222,4 @@ jobs:
           mkdir -p ./html/web/sites/simpletest && chmod 777 ./html/web/sites/simpletest
           sed -i "s#http://localgov.lndo.site#http://drupal#" ./html/phpunit.xml.dist
           docker exec -t drupal bash -c 'chown docker:docker -R /var/www/html'
-          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 /var/www/html/${{inputs.project_path}}"
+          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/phpunit /var/www/html/${{inputs.project_path}}"


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Replace paratest with phpunit so we can see failure messages.

The main project will remain as paratest as it will run faster with all the tests it needs to run, this PR will only update workflows for modules.