### PR TITLE
fix: only run phpstan if there are php files to check

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -178,6 +178,7 @@ jobs:
         run: echo "PHPSTAN_NEON_PATH=\"${{inputs.project_path}}/phpstan.neon\"" >> $GITHUB_ENV
 
       - name: Run static analysis checks
+        if: ${{ hashFiles(format('./html/{0}/**/*.inc', inputs.project_path), format('./html/{0}/**/*.install', inputs.project_path), format('./html/{0}/**/*.info', inputs.project_path), format('./html/{0}/**/*.test', inputs.project_path), format('./html/{0}/**/*.module', inputs.project_path), format('./html/{0}/**/*.php', inputs.project_path), format('./html/{0}/**/*.profile', inputs.project_path), format('./html/{0}/**/*.test', inputs.project_path), format('./html/{0}/**/*.theme', inputs.project_path)) != '' }}
         run: |
           cd html
           ./bin/phpstan analyse -c ${{ env.PHPSTAN_NEON_PATH }} ${{inputs.project_path}}

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -178,7 +178,7 @@ jobs:
         run: echo "PHPSTAN_NEON_PATH=\"${{inputs.project_path}}/phpstan.neon\"" >> $GITHUB_ENV
 
       - name: Run static analysis checks
-        if: ${{ hashFiles(format('./html/{0}/**/*.inc', inputs.project_path), format('./html/{0}/**/*.install', inputs.project_path), format('./html/{0}/**/*.info', inputs.project_path), format('./html/{0}/**/*.test', inputs.project_path), format('./html/{0}/**/*.module', inputs.project_path), format('./html/{0}/**/*.php', inputs.project_path), format('./html/{0}/**/*.profile', inputs.project_path), format('./html/{0}/**/*.test', inputs.project_path), format('./html/{0}/**/*.theme', inputs.project_path)) != '' }}
+        if: ${{ hashFiles(format('./html/{0}/**/*.inc', inputs.project_path), format('./html/{0}/**/*.install', inputs.project_path), format('./html/{0}/**/*.module', inputs.project_path), format('./html/{0}/**/*.php', inputs.project_path), format('./html/{0}/**/*.profile', inputs.project_path), format('./html/{0}/**/*.test', inputs.project_path), format('./html/{0}/**/*.theme', inputs.project_path)) != '' }}
         run: |
           cd html
           ./bin/phpstan analyse -c ${{ env.PHPSTAN_NEON_PATH }} ${{inputs.project_path}}


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #12 this updates the shared workflows to ignore the PHPStan check if no php files are present and prevent it failing e.g. https://github.com/localgovdrupal/localgov_claro/actions/runs/10794804206