### PR TITLE
feat: copy core prettier file before running checks

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -112,7 +112,6 @@ jobs:
     name: ESLint javascript checks
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
 
     strategy:
       fail-fast: false
@@ -148,7 +147,6 @@ jobs:
     name: ESLint yaml checks
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
 
     strategy:
       fail-fast: false
@@ -170,11 +168,13 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
+        if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
 
       - name: Run coding standards checks
+        if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           cp -f .prettierrc.json ../.prettierrc.json
@@ -184,7 +184,6 @@ jobs:
     name: Stylelint checks
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
 
     strategy:
       fail-fast: false
@@ -206,11 +205,13 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
+        if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
 
       - name: Run coding standards checks
+        if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           cp -f .prettierrc.json ../.prettierrc.json

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -133,11 +133,13 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
+        if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
 
       - name: Run coding standards checks
+        if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           cp -f .prettierrc.json ../.prettierrc.json

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -112,6 +112,7 @@ jobs:
     name: ESLint javascript checks
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
 
     strategy:
       fail-fast: false
@@ -133,21 +134,21 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
-        if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
 
       - name: Run coding standards checks
-        if: ${{ hashFiles(format('./html/{0}/**/*.js', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
+          cp -f .prettierrc.json ../.prettierrc.json
           node ./node_modules/eslint/bin/eslint.js --ext .js --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 
   eslint_yaml:
     name: ESLint yaml checks
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
 
     strategy:
       fail-fast: false
@@ -169,21 +170,21 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
-        if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
 
       - name: Run coding standards checks
-        if: ${{ hashFiles(format('./html/{0}/**/*.yml', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
+          cp -f .prettierrc.json ../.prettierrc.json
           node ./node_modules/eslint/bin/eslint.js --ext .yml --resolve-plugins-relative-to=./web/core ../../${{inputs.project_path}}
 
   stylelint:
     name: Stylelint checks
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
 
     strategy:
       fail-fast: false
@@ -205,15 +206,14 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Install packages
-        if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
           npm i
 
       - name: Run coding standards checks
-        if: ${{ hashFiles(format('./html/{0}/**/*.css', inputs.project_path)) != '' }}
         run: |
           cd html/web/core
+          cp -f .prettierrc.json ../.prettierrc.json
           node ./node_modules/.bin/stylelint --ignore-path .stylelintignore --config .stylelintrc.json "../../${{inputs.project_path}}/**/*.css"
 
   phpcs:


### PR DESCRIPTION
## What does this change?

While working on https://github.com/localgovdrupal/localgov_core/pull/266 I noticed prettier was trying to replace `'` with `"` which is incorrect as the [core prettier config](https://git.drupalcode.org/project/drupal/-/blob/10.4.x/core/.prettierrc.json) has `"singleQuote": true,`. This is because it tries to use the config from `web` which is fine for eslint as it extends the eslint config from `web/core`. Prettier cannot do this so I've added a workflow step to copy the file before checks are run.

See https://github.com/localgovdrupal/localgov_core/actions/runs/12560386043/job/35017748492
![Screenshot 2024-12-31 at 14 09 40](https://github.com/user-attachments/assets/9d9ea8a6-dab0-4a63-adf6-444791375b8f)
